### PR TITLE
0.3.0: Fetcher config builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fastnear Inc <hello@fastnear.com>"]
 edition = "2021"
 repository = "https://github.com/fastnear/libs"
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
 serde_with = { version = "3.0", features = ["base64"] }
-reqwest = { version = "0.12.2", features = ["json"] }
+reqwest = { version = "0.12.2", features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["time", "sync", "rt-multi-thread"] }
 tracing = { version = "0.1.13", features = ["log"] }
 borsh = { version = "1.5.0", features = ["derive"] }
@@ -31,4 +31,5 @@ near-jsonrpc-primitives = "0.29.1"
 near-chain-configs = "0.29.1"
 tar = "0.4.43"
 flate2 = "1.0"
+url = "2.5.4"
 

--- a/flat-state/Cargo.toml
+++ b/flat-state/Cargo.toml
@@ -23,8 +23,8 @@ near-chain-configs = { workspace = true, optional = true }
 near-jsonrpc-client = { workspace = true, optional = true }
 near-jsonrpc-primitives = { workspace = true, optional = true }
 
-fastnear-primitives = { version = "0.2.0", path = "../primitives" }
-fastnear-neardata-fetcher = { version = "0.2.0", path = "../neardata-fetcher", optional = true }
+fastnear-primitives = { version = "0.3.0", path = "../primitives" }
+fastnear-neardata-fetcher = { version = "0.3.0", path = "../neardata-fetcher", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/neardata-fetcher/Cargo.toml
+++ b/neardata-fetcher/Cargo.toml
@@ -16,8 +16,9 @@ tracing.workspace = true
 tar.workspace = true
 flate2.workspace = true
 serde_json.workspace = true
+url.workspace = true
 
-fastnear-primitives = { version = "0.2.0", path = "../primitives" }
+fastnear-primitives = { version = "0.3.0", path = "../primitives" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/neardata-fetcher/README.md
+++ b/neardata-fetcher/README.md
@@ -2,4 +2,48 @@
 
 This crate provides a fetcher to retrieve data from neardata.xyz
 
-Use `fetcher::start_fetcher` to start the fetcher.
+Handle ctrl-c signal to stop the fetcher.
+
+```rust
+pub fn running() -> Arc<AtomicBool> {
+    let is_running = Arc::new(AtomicBool::new(true));
+    let ctrl_c_running = is_running.clone();
+
+    ctrlc::set_handler(move || {
+        ctrl_c_running.store(false, Ordering::SeqCst);
+        println!("Received Ctrl+C, starting shutdown...");
+    })
+        .expect("Error setting Ctrl+C handler");
+
+    is_running
+}
+```
+
+Configure the fetcher using `FetcherConfigBuilder`, e.g.
+
+```rust
+pub fn fetcher_config() -> fetcher::FetcherConfig {
+    let mut fetcher_config_builder = fetcher::FetcherConfigBuilder::new()
+        .num_threads(num_threads.parse::<u64>().unwrap())
+        .chain_id(chain_id)
+        .finality(finality);
+    if !auth_bearer_token.is_empty() {
+        fetcher_config_builder = fetcher_config_builder.auth_bearer_token(auth_bearer_token);
+    }
+    fetcher_config_builder.build()
+}
+```
+
+Create a channel, and start a fetcher:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (sender, receiver) = mpsc::channel(100);
+    tokio::spawn(fetcher::start_fetcher(fetcher_config(), sender, running()));
+
+    listen_blocks(receiver).await;
+}
+```
+
+See `examples` for more details.

--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -199,7 +199,7 @@ impl Fetcher {
             ChainId::Testnet => "https://testnet.neardata.xyz/raw/".to_string(),
         };
         let url = format!("{}{}", prefix, suffix);
-        tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching archive url: {}", url);
+        tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching archive url: {}", archive_block_height, url);
         while self.is_running.load(Ordering::SeqCst) {
             match self.fetch_archive(&url).await {
                 Ok(Some(archive)) => match self.parse_archive(archive) {

--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -384,7 +384,7 @@ pub async fn start_fetcher(
                 tokio::spawn(async move {
                     while fetcher.is_running.load(Ordering::SeqCst) {
                         let block_height = next_fetch_block.fetch_add(1, Ordering::SeqCst);
-                        if is_backfill && block_height > last_block_height || block_height > end_block_height {
+                        if (is_backfill && block_height > last_block_height) || block_height > end_block_height {
                             break;
                         }
                         tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching block: {}", thread_index, block_height);

--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -3,12 +3,15 @@ pub use crate::utils::*;
 use crate::*;
 use fastnear_primitives::near_primitives::types::Finality;
 use fastnear_primitives::near_primitives::views::BlockView;
+use reqwest::ClientBuilder;
 use std::io::Read;
 
 #[derive(Debug)]
 struct InterruptedError;
 
 type InterruptibleResult<T> = Result<T, InterruptedError>;
+
+pub const MAX_REDIRECTS: usize = 5;
 
 #[derive(Clone)]
 struct Fetcher {
@@ -22,15 +25,40 @@ impl Fetcher {
     where
         T: serde::de::DeserializeOwned,
     {
-        let mut request = self.client.get(url);
-        if let Some(token) = &self.config.auth_bearer_token {
-            request = request.bearer_auth(token);
+        // Manually handle redirects and adding auth headers
+        let mut url = url.to_string();
+        for _ in 0..MAX_REDIRECTS {
+            let mut request = self.client.get(&url);
+            if let Some(token) = &self.config.auth_bearer_token {
+                request = request.bearer_auth(token);
+            }
+            let response = request
+                .timeout(self.config.timeout_duration.unwrap_or(DEFAULT_TIMEOUT))
+                .send()
+                .await?;
+
+            if response.status().is_redirection() {
+                let location = response
+                    .headers()
+                    .get(reqwest::header::LOCATION)
+                    .ok_or(FetchError::RedirectError)?
+                    .to_str()
+                    .map_err(|_| FetchError::RedirectError)?;
+
+                let parsed_current =
+                    url::Url::parse(&url).map_err(|_| FetchError::RedirectError)?;
+
+                // Resolve the location relative to the current URL
+                url = parsed_current
+                    .join(location)
+                    .map_err(|_| FetchError::RedirectError)?
+                    .to_string();
+                continue;
+            }
+
+            return Ok(response.json().await?);
         }
-        let response = request
-            .timeout(self.config.timeout_duration.unwrap_or(DEFAULT_TIMEOUT))
-            .send()
-            .await?;
-        Ok(response.json().await?)
+        Err(FetchError::RedirectError)
     }
 
     pub async fn fetch_until_success<T>(&self, url: &str) -> InterruptibleResult<Option<T>>
@@ -42,6 +70,13 @@ impl Fetcher {
                 Ok(block) => return Ok(block),
                 Err(FetchError::ReqwestError(err)) => {
                     tracing::log::warn!(target: LOG_TARGET, "Failed to fetch: {}", err);
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::RedirectError) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Redirect error");
                     tokio::time::sleep(
                         self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
                     )
@@ -142,14 +177,20 @@ impl Fetcher {
             padded_block_height
         );
         let prefix = match self.config.chain_id {
-            ChainId::Mainnet if archive_block_height <= MAINNET_ARCHIVE_LAST_BLOCK_HEIGHT => {
-                "https://archive.data.fastnear.com/mainnet/"
+            ChainId::Mainnet if archive_block_height < MAINNET_R2_LAST_BLOCK_HEIGHT => {
+                "https://archive.data.fastnear.com/mainnet/".to_string()
             }
             ChainId::Testnet if archive_block_height <= TESTNET_ARCHIVE_LAST_BLOCK_HEIGHT => {
-                "https://archive.data.fastnear.com/mainnet/"
+                "https://archive.data.fastnear.com/mainnet/".to_string()
             }
-            ChainId::Mainnet => "https://a1.mainnet.neardata.xyz/raw/",
-            ChainId::Testnet => "https://testnet.neardata.xyz/raw/",
+            ChainId::Mainnet => format!(
+                "https://a{}.mainnet.neardata.xyz/raw/",
+                MAINNET_ARCHIVE_BOUNDARIES
+                    .iter()
+                    .position(|&b| archive_block_height < b)
+                    .unwrap_or(MAINNET_ARCHIVE_BOUNDARIES.len())
+            ),
+            ChainId::Testnet => "https://testnet.neardata.xyz/raw/".to_string(),
         };
         let url = format!("{}{}", prefix, suffix);
         while self.is_running.load(Ordering::SeqCst) {
@@ -167,6 +208,13 @@ impl Fetcher {
                 Ok(None) => return Ok(Vec::new()),
                 Err(FetchError::ReqwestError(err)) => {
                     tracing::log::warn!(target: LOG_TARGET, "Failed to fetch the archive: {}", err);
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::RedirectError) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Redirect error");
                     tokio::time::sleep(
                         self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
                     )
@@ -245,12 +293,14 @@ async fn archive_sync(
 }
 
 pub async fn start_fetcher(
-    client: Option<Client>,
     config: FetcherConfig,
     blocks_sink: mpsc::Sender<BlockWithTxHashes>,
     is_running: Arc<AtomicBool>,
 ) {
-    let client = client.unwrap_or_else(|| Client::new());
+    let client = ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
     let fetcher = Fetcher {
         client,
         config,
@@ -272,9 +322,13 @@ pub async fn start_fetcher(
             .header
             .height
     };
+    let end_block_height = fetcher.config.end_block_height.unwrap_or(std::u64::MAX);
     let next_sink_block = Arc::new(AtomicU64::new(start_block_height));
     while fetcher.is_running.load(Ordering::SeqCst) {
         let start_block_height = next_sink_block.load(Ordering::SeqCst);
+        if start_block_height > end_block_height {
+            break;
+        }
         let last_block_height = fetcher
             .fetch_last_block_headers(&fetcher.config.finality)
             .await;
@@ -286,6 +340,7 @@ pub async fn start_fetcher(
             .expect("Last block doesn't exist")
             .header
             .height;
+        let last_block_height = std::cmp::min(last_block_height, end_block_height);
         let rounded_last_block_height =
             last_block_height / NUMBER_OF_BLOCKS_PER_ARCHIVE * NUMBER_OF_BLOCKS_PER_ARCHIVE;
         if !fetcher.config.disable_archive_sync
@@ -322,7 +377,7 @@ pub async fn start_fetcher(
                 tokio::spawn(async move {
                     while fetcher.is_running.load(Ordering::SeqCst) {
                         let block_height = next_fetch_block.fetch_add(1, Ordering::SeqCst);
-                        if is_backfill && block_height > last_block_height {
+                        if is_backfill && block_height > last_block_height || block_height > end_block_height {
                             break;
                         }
                         tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching block: {}", thread_index, block_height);

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -31,6 +31,7 @@ pub struct FetcherConfig {
     /// The Bearer token to use for authentication
     pub auth_bearer_token: Option<String>,
     pub finality: Finality,
+    pub enable_r2_archive_sync: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +52,7 @@ impl FetcherConfigBuilder {
                 disable_archive_sync: false,
                 auth_bearer_token: None,
                 finality: Finality::Final,
+                enable_r2_archive_sync: false,
             },
         }
     }
@@ -99,6 +101,12 @@ impl FetcherConfigBuilder {
 
     pub fn finality(mut self, finality: Finality) -> Self {
         self.config.finality = finality;
+        self
+    }
+
+    /// R2 endpoint has lower rate limits and should be used with authentication
+    pub fn enable_r2_archive_sync(mut self, enable_r2_archive_sync: bool) -> Self {
+        self.config.enable_r2_archive_sync = enable_r2_archive_sync;
         self
     }
 

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -8,6 +8,7 @@ pub type BlockResult = Result<Option<BlockWithTxHashes>, FetchError>;
 #[derive(Debug)]
 pub enum FetchError {
     ReqwestError(reqwest::Error),
+    RedirectError,
 }
 
 impl From<reqwest::Error> for FetchError {
@@ -19,7 +20,10 @@ impl From<reqwest::Error> for FetchError {
 #[derive(Debug, Clone)]
 pub struct FetcherConfig {
     pub num_threads: u64,
+    /// The start block height to fetch from (inclusive)
     pub start_block_height: Option<BlockHeight>,
+    /// The end block height to fetch up to (inclusive)
+    pub end_block_height: Option<BlockHeight>,
     pub chain_id: ChainId,
     pub timeout_duration: Option<Duration>,
     pub retry_duration: Option<Duration>,
@@ -27,4 +31,78 @@ pub struct FetcherConfig {
     /// The Bearer token to use for authentication
     pub auth_bearer_token: Option<String>,
     pub finality: Finality,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetcherConfigBuilder {
+    config: FetcherConfig,
+}
+
+impl FetcherConfigBuilder {
+    pub fn new() -> Self {
+        FetcherConfigBuilder {
+            config: FetcherConfig {
+                num_threads: 4,
+                start_block_height: None,
+                end_block_height: None,
+                chain_id: ChainId::Mainnet,
+                timeout_duration: None,
+                retry_duration: None,
+                disable_archive_sync: false,
+                auth_bearer_token: None,
+                finality: Finality::Final,
+            },
+        }
+    }
+
+    pub fn num_threads(mut self, num_threads: u64) -> Self {
+        self.config.num_threads = num_threads;
+        self
+    }
+
+    /// The start block height to fetch from (inclusive)
+    pub fn start_block_height(mut self, start_block_height: BlockHeight) -> Self {
+        self.config.start_block_height = Some(start_block_height);
+        self
+    }
+
+    /// The end block height to fetch up to (inclusive)
+    pub fn end_block_height(mut self, end_block_height: BlockHeight) -> Self {
+        self.config.end_block_height = Some(end_block_height);
+        self
+    }
+
+    pub fn chain_id(mut self, chain_id: ChainId) -> Self {
+        self.config.chain_id = chain_id;
+        self
+    }
+
+    pub fn timeout_duration(mut self, timeout_duration: Duration) -> Self {
+        self.config.timeout_duration = Some(timeout_duration);
+        self
+    }
+
+    pub fn retry_duration(mut self, retry_duration: Duration) -> Self {
+        self.config.retry_duration = Some(retry_duration);
+        self
+    }
+
+    pub fn disable_archive_sync(mut self, disable_archive_sync: bool) -> Self {
+        self.config.disable_archive_sync = disable_archive_sync;
+        self
+    }
+
+    pub fn auth_bearer_token(mut self, auth_bearer_token: String) -> Self {
+        self.config.auth_bearer_token = Some(auth_bearer_token);
+        self
+    }
+
+    pub fn finality(mut self, finality: Finality) -> Self {
+        self.config.finality = finality;
+        self
+    }
+
+    pub fn build(self) -> FetcherConfig {
+        self.config
+    }
 }

--- a/neardata-fetcher/src/utils.rs
+++ b/neardata-fetcher/src/utils.rs
@@ -5,7 +5,7 @@ pub const LOG_TARGET: &str = "neardata-fetcher";
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);
 
-pub(crate) const MAINNET_R2_LAST_BLOCK_HEIGHT: u64 = 142000000;
+pub(crate) const MAINNET_R2_LAST_BLOCK_HEIGHT: u64 = 141999999;
 pub(crate) const TESTNET_ARCHIVE_LAST_BLOCK_HEIGHT: u64 = 185670000;
 pub(crate) const MAINNET_ARCHIVE_BOUNDARIES: &[u64] = &[122000000, 142000000];
 

--- a/neardata-fetcher/src/utils.rs
+++ b/neardata-fetcher/src/utils.rs
@@ -5,8 +5,10 @@ pub const LOG_TARGET: &str = "neardata-fetcher";
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);
 
-pub(crate) const MAINNET_ARCHIVE_LAST_BLOCK_HEIGHT: u64 = 138046960;
+pub(crate) const MAINNET_R2_LAST_BLOCK_HEIGHT: u64 = 142000000;
 pub(crate) const TESTNET_ARCHIVE_LAST_BLOCK_HEIGHT: u64 = 185670000;
+pub(crate) const MAINNET_ARCHIVE_BOUNDARIES: &[u64] = &[122000000, 142000000];
+
 pub(crate) const NUMBER_OF_BLOCKS_PER_ARCHIVE: u64 = 10;
 pub(crate) const ARCHIVE_SYNC_THRESHOLD: u64 = NUMBER_OF_BLOCKS_PER_ARCHIVE * 2;
 
@@ -30,6 +32,10 @@ pub async fn fetch_block_until_success(
             Err(FetchError::ReqwestError(err)) => {
                 tracing::log::warn!(target: LOG_TARGET, "Failed to fetch block: {}", err);
                 tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(FetchError::RedirectError) => {
+                tracing::log::warn!(target: LOG_TARGET, "Redirect error");
+                return None;
             }
         }
     }


### PR DESCRIPTION
# `0.3.0`

- Handle auth header on redirects
- Introduce `FetcherConfigBuilder`
- Add `end_block_height` in the `FetcherConfig`
- Add `enable_r2_archive_sync` in the `FetcherConfig`
- Fetcher no longer accept the `reqwest::Client`. Needed to handle redirects properly.
- Updated README.md for fetcher
- Updated archive links and boundaries