### PR TITLE
Support multiple threads for normal fetching mode

### DIFF
--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -318,6 +318,7 @@ pub async fn start_fetcher(
         is_running,
     };
     let max_num_threads = fetcher.config.num_threads;
+    let num_lookahead_threads = fetcher.config.num_lookahead_threads;
     let start_block_height = if let Some(start_block_height) = fetcher.config.start_block_height {
         start_block_height
     } else {
@@ -369,7 +370,11 @@ pub async fn start_fetcher(
         }
         let next_fetch_block = Arc::new(AtomicU64::new(start_block_height));
         let is_backfill = last_block_height > start_block_height + max_num_threads;
-        let num_threads = if is_backfill { max_num_threads } else { 1 };
+        let num_threads = if is_backfill {
+            max_num_threads
+        } else {
+            num_lookahead_threads
+        };
         tracing::log::info!(
             target: LOG_TARGET,
             "Start fetching from block {} to block {} with {} threads. Backfill: {:?}",

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -33,6 +33,9 @@ pub struct FetcherConfig {
     pub finality: Finality,
     pub enable_r2_archive_sync: bool,
     pub user_agent: Option<String>,
+    /// The number of threads for regular fetching. It will attempt to fetch future blocks.
+    /// Note, the number can't be too high, as it will be denied by the server.
+    pub num_lookahead_threads: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -55,6 +58,7 @@ impl FetcherConfigBuilder {
                 finality: Finality::Final,
                 enable_r2_archive_sync: false,
                 user_agent: None,
+                num_lookahead_threads: 4,
             },
         }
     }


### PR DESCRIPTION
This change should improve reliability of regular sync, since latency will go in parallel instead of sequential accumulation