### PR TITLE
Rate limit handling

### DIFF
--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -3,7 +3,7 @@ pub use crate::utils::*;
 use crate::*;
 use fastnear_primitives::near_primitives::types::Finality;
 use fastnear_primitives::near_primitives::views::BlockView;
-use reqwest::ClientBuilder;
+use reqwest::{ClientBuilder, StatusCode};
 use std::io::Read;
 
 #[derive(Debug)]
@@ -56,7 +56,11 @@ impl Fetcher {
                 continue;
             }
 
-            return Ok(response.json().await?);
+            return match response.status() {
+                status if status.is_success() => Ok(response.json().await?),
+                StatusCode::TOO_MANY_REQUESTS => Err(FetchError::RateLimitError),
+                status => Err(FetchError::UnexpectedStatus(status)),
+            };
         }
         Err(FetchError::RedirectError)
     }
@@ -77,6 +81,20 @@ impl Fetcher {
                 }
                 Err(FetchError::RedirectError) => {
                     tracing::log::warn!(target: LOG_TARGET, "Redirect error");
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::RateLimitError) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Rate limited when fetching: {}", url);
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::UnexpectedStatus(status)) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Unexpected status when fetching {}: {}", url, status);
                     tokio::time::sleep(
                         self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
                     )
@@ -141,10 +159,17 @@ impl Fetcher {
             .timeout(self.config.timeout_duration.unwrap_or(DEFAULT_TIMEOUT))
             .send()
             .await?;
-        if response.status() == 404 {
-            return Ok(None);
+        match response.status() {
+            StatusCode::NOT_FOUND => {
+                tracing::log::debug!(target: LOG_TARGET, "Archive not found: {}", url);
+                Ok(None)
+            }
+            StatusCode::TOO_MANY_REQUESTS => Err(FetchError::RateLimitError),
+            status if status.is_success() => {
+                Ok(response.bytes().await.map(|b| Some(b.to_vec()))?)
+            }
+            status => Err(FetchError::UnexpectedStatus(status)),
         }
-        Ok(response.bytes().await.map(|b| Some(b.to_vec()))?)
     }
 
     fn parse_archive(&self, archive: Vec<u8>) -> Result<Vec<BlockWithTxHashes>, String> {
@@ -222,6 +247,20 @@ impl Fetcher {
                 }
                 Err(FetchError::RedirectError) => {
                     tracing::log::warn!(target: LOG_TARGET, "Redirect error");
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::RateLimitError) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Rate limited when fetching archive: {}", url);
+                    tokio::time::sleep(
+                        self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
+                    )
+                    .await;
+                }
+                Err(FetchError::UnexpectedStatus(status)) => {
+                    tracing::log::warn!(target: LOG_TARGET, "Unexpected status when fetching archive {}: {}", url, status);
                     tokio::time::sleep(
                         self.config.retry_duration.unwrap_or(DEFAULT_RETRY_DURATION),
                     )

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
 use fastnear_primitives::near_primitives::types::Finality;
+use reqwest::StatusCode;
 use std::time::Duration;
 
 pub type BlockResult = Result<Option<BlockWithTxHashes>, FetchError>;
@@ -8,7 +9,9 @@ pub type BlockResult = Result<Option<BlockWithTxHashes>, FetchError>;
 #[derive(Debug)]
 pub enum FetchError {
     ReqwestError(reqwest::Error),
+    RateLimitError,
     RedirectError,
+    UnexpectedStatus(StatusCode),
 }
 
 impl From<reqwest::Error> for FetchError {

--- a/neardata-fetcher/src/utils.rs
+++ b/neardata-fetcher/src/utils.rs
@@ -37,6 +37,14 @@ pub async fn fetch_block_until_success(
                 tracing::log::warn!(target: LOG_TARGET, "Redirect error");
                 return None;
             }
+            Err(FetchError::RateLimitError) => {
+                tracing::log::warn!(target: LOG_TARGET, "Rate limited, retrying...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(FetchError::UnexpectedStatus(status)) => {
+                tracing::log::warn!(target: LOG_TARGET, "Unexpected status code: {}", status);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
         }
     }
 }


### PR DESCRIPTION
- Check for rate-limit errors and fail with better messaging. It will retry in a sec.
- Don't fetch unless success.