### PR TITLE
Add lookahead to config builder

### DIFF
--- a/neardata-fetcher/examples/simple_fetcher.rs
+++ b/neardata-fetcher/examples/simple_fetcher.rs
@@ -39,6 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start_block_height = input("Enter start block height (empty - from latest)", Some(""))?;
     let end_block_height = input("Enter end block height (empty - no end)", Some(""))?;
     let num_threads = input("Enter the number of threads", Some("8"))?;
+    let num_lookahead_threads = input("Enter the number of lookahead threads", Some("4"))?;
     let auth_bearer_token = input("Enter the auth bearer token (optional)", None)?;
 
     println!("Starting fetcher");
@@ -54,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut fetcher_config_builder = fetcher::FetcherConfigBuilder::new()
         .num_threads(num_threads.parse::<u64>().unwrap())
+        .num_lookahead_threads(num_lookahead_threads.parse::<u64>().unwrap())
         .chain_id(chain_id)
         .finality(finality);
     if !start_block_height.is_empty() {

--- a/neardata-fetcher/src/fetcher.rs
+++ b/neardata-fetcher/src/fetcher.rs
@@ -291,48 +291,48 @@ async fn archive_sync(
     ));
     // starting backfill with multiple threads
     let handles = (0..fetcher.config.num_threads)
-            .map(|thread_index| {
-                let fetcher = fetcher.clone();
-                let blocks_sink = blocks_sink.clone();
-                let next_fetch_archive_height = next_fetch_archive_height.clone();
-                let next_sink_block = next_sink_block.clone();
-                tokio::spawn(async move {
-                    while fetcher.is_running.load(Ordering::SeqCst) {
-                        let archive_block_height = next_fetch_archive_height.fetch_add(NUMBER_OF_BLOCKS_PER_ARCHIVE, Ordering::SeqCst);
-                        if archive_block_height >= end_block_height {
-                            break;
-                        }
-                        tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching archive: {}", thread_index, archive_block_height);
-                        let blocks =
-                            fetcher.fetch_blocks_from_archive(archive_block_height).await;
-                        let mut expected_block_height = 0;
-                        while fetcher.is_running.load(Ordering::SeqCst) {
-                            expected_block_height = next_sink_block.load(Ordering::SeqCst);
-                            if expected_block_height < archive_block_height {
-                                tokio::time::sleep(Duration::from_millis(
-                                    (archive_block_height - expected_block_height + NUMBER_OF_BLOCKS_PER_ARCHIVE - 1) / NUMBER_OF_BLOCKS_PER_ARCHIVE * NUMBER_OF_BLOCKS_PER_ARCHIVE,
-                                ))
-                                    .await;
-                            } else {
-                                tracing::log::debug!(target: LOG_TARGET, "#{}: Sending blocks from archive: {}", thread_index, archive_block_height);
-                                break;
-                            }
-                        }
-                        if !fetcher.is_running.load(Ordering::SeqCst) {
-                            break;
-                        }
-                        for block in blocks.expect("Can't be interrupted error") {
-                            // Skipping initial blocks from archive
-                            if block.block.header.height < expected_block_height {
-                                continue;
-                            }
-                            blocks_sink.send(block).await.expect("Failed to send block");
-                        }
-                        next_sink_block.swap(archive_block_height + NUMBER_OF_BLOCKS_PER_ARCHIVE, Ordering::SeqCst);
+        .map(|thread_index| {
+            let fetcher = fetcher.clone();
+            let blocks_sink = blocks_sink.clone();
+            let next_fetch_archive_height = next_fetch_archive_height.clone();
+            let next_sink_block = next_sink_block.clone();
+            tokio::spawn(async move {
+                while fetcher.is_running.load(Ordering::SeqCst) {
+                    let archive_block_height = next_fetch_archive_height.fetch_add(NUMBER_OF_BLOCKS_PER_ARCHIVE, Ordering::SeqCst);
+                    if archive_block_height >= end_block_height {
+                        break;
                     }
-                })
+                    tracing::log::debug!(target: LOG_TARGET, "#{}: Fetching archive: {}", thread_index, archive_block_height);
+                    let blocks =
+                        fetcher.fetch_blocks_from_archive(archive_block_height).await;
+                    let mut expected_block_height = 0;
+                    while fetcher.is_running.load(Ordering::SeqCst) {
+                        expected_block_height = next_sink_block.load(Ordering::SeqCst);
+                        if expected_block_height < archive_block_height {
+                            tokio::time::sleep(Duration::from_millis(
+                                (archive_block_height - expected_block_height + NUMBER_OF_BLOCKS_PER_ARCHIVE - 1) / NUMBER_OF_BLOCKS_PER_ARCHIVE * NUMBER_OF_BLOCKS_PER_ARCHIVE,
+                            ))
+                                .await;
+                        } else {
+                            tracing::log::debug!(target: LOG_TARGET, "#{}: Sending blocks from archive: {}", thread_index, archive_block_height);
+                            break;
+                        }
+                    }
+                    if !fetcher.is_running.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    for block in blocks.expect("Can't be interrupted error") {
+                        // Skipping initial blocks from archive
+                        if block.block.header.height < expected_block_height {
+                            continue;
+                        }
+                        blocks_sink.send(block).await.expect("Failed to send block");
+                    }
+                    next_sink_block.swap(archive_block_height + NUMBER_OF_BLOCKS_PER_ARCHIVE, Ordering::SeqCst);
+                }
             })
-            .collect::<Vec<_>>();
+        })
+        .collect::<Vec<_>>();
     for handle in handles {
         handle.await.expect("Failed to join fetching thread");
     }

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -126,7 +126,7 @@ impl FetcherConfigBuilder {
 
     pub fn num_lookahead_threads(mut self, num_lookahead_threads: u64) -> Self {
         if num_lookahead_threads > 12 {
-            tracing::warn!(
+            tracing::warn!(target: "neardata-fetcher",
                 "num_lookahead_threads is too high, recommended to be <= 12 to avoid server denial"
             );
         }

--- a/neardata-fetcher/src/types.rs
+++ b/neardata-fetcher/src/types.rs
@@ -124,6 +124,16 @@ impl FetcherConfigBuilder {
         self
     }
 
+    pub fn num_lookahead_threads(mut self, num_lookahead_threads: u64) -> Self {
+        if num_lookahead_threads > 12 {
+            tracing::warn!(
+                "num_lookahead_threads is too high, recommended to be <= 12 to avoid server denial"
+            );
+        }
+        self.config.num_lookahead_threads = num_lookahead_threads;
+        self
+    }
+
     pub fn build(self) -> FetcherConfig {
         self.config
     }


### PR DESCRIPTION
- Reformat fetcher
- Add `num_lookahead_threads` to config builder